### PR TITLE
- attempt fix catch compile error for tests

### DIFF
--- a/.test/test.cpp
+++ b/.test/test.cpp
@@ -4,6 +4,7 @@
 #include "../maths.h"
 #include <stdio.h>
 
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 


### PR DESCRIPTION
fixes issue with gcc / clang tests, when MINSIGSTKSZ is no longer a constant